### PR TITLE
Bump Kong to version 1.0.3

### DIFF
--- a/config/blobs.yml
+++ b/config/blobs.yml
@@ -1,5 +1,6 @@
 kong/kong-1.0.3.tar.gz:
   size: 668128
+  object_id: dc0b19cb-ac42-4382-54d3-113df0ebfe95
   sha: sha256:ab92aa802304f3055c8e0a35901e995e4fe91415c286158b39d31622a2319df9
 konga/konga-0.14.4.tar.gz:
   size: 1936120

--- a/config/blobs.yml
+++ b/config/blobs.yml
@@ -1,7 +1,6 @@
-kong/kong-0.15.0.tar.gz:
-  size: 862950
-  object_id: 562b8db9-601a-42fb-54a5-70ebdecc96fa
-  sha: sha256:6c4fb2ff7a0c7dbe824607a5682a87f688a7a89d54ee34564e365bdf7fdc135d
+kong/kong-1.0.3.tar.gz:
+  size: 668128
+  sha: sha256:ab92aa802304f3055c8e0a35901e995e4fe91415c286158b39d31622a2319df9
 konga/konga-0.14.4.tar.gz:
   size: 1936120
   object_id: 37e0263b-bbef-4fd9-7b59-56edaf6c1a9d


### PR DESCRIPTION
Hi there!

I noticed that the new Kong v1.0.3 is out, so I suggest we update this BOSH Release with the latest binary available.

Here in this PR, I've pulled that new binary in, and the tests are passing properly. So I uploaded the blob to the release blobstore, and here is the result.

Let's give it a shot, shall we?

Best